### PR TITLE
.github: add hardware test workflow

### DIFF
--- a/.github/workflows/hw-test.yaml
+++ b/.github/workflows/hw-test.yaml
@@ -1,0 +1,52 @@
+name: Hardware Test
+
+on:
+  workflow_run:
+    workflows: ["Build ADI artifacts"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  hardware-test:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ${{ vars.RUNNER_HW_TEST != '' && fromJSON(vars.RUNNER_HW_TEST) || 'ubuntu-latest' }}
+    env:
+      LG_COORDINATOR: ${{ secrets.LG_COORDINATOR }}
+
+    steps:
+      - name: Checkout hw-test
+        uses: actions/checkout@v6
+        with:
+          repository: analogdevicesinc/hw-test
+          ref: add-smoke2
+
+      - name: Run smoke hardware test
+        uses: ./run-test
+        with:
+          set: >
+            {
+              "name": "adsp/smoke",
+              "labgrid_place":"MUN-01-SC598_EZKIT-01"
+            }
+
+      - name: Run U-Boot hardware test
+        uses: ./run-test
+        with:
+          set: >
+            {
+              "name":"adsp/u-boot",
+              "labgrid_place":"MUN-01-SC598_EZKIT-01"
+            }
+
+      - name: Run bootstrap hardware test
+        uses: ./run-test
+        with:
+          set: >
+            {
+              "name":"adsp/bootstrap",
+              "labgrid_place":"MUN-01-SC598_EZKIT-01"
+            }


### PR DESCRIPTION
Add a workflow to run the SC598 hardware tests against the bootstrap image artifacts produced by the build workflow.

Trigger the workflow automatically when "Build ADI artifacts" completes and keep a manual workflow_dispatch entry point for rerunning tests against a specific build run.