### PR TITLE
.github: run a build nightly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
   release:
     types: [published]
+  schedule:
+    - cron: '0 4 * * *' # 04:00 UTC (05:00/06:00 CET/CEST, 23:00/00:00 EST/EDT)
 
 env:
   BR2_DL_DIR: ~/.buildroot-dl


### PR DESCRIPTION
An issue fetching the u-boot.gdb script showed that failures can occur outside br2_external, which will impact users. Nightly builds can catch these issues before users experience them.