### PR TITLE
.github/build: configurable runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
 
     strategy:
       matrix:


### PR DESCRIPTION
'runs-on' is or conditional, 'self-hosted' matches a runner called "['self-hosted', 'labgrid']". Also for forks requires the user to setup its own self-hosted. Use conditionals to fallback to 'ubuntu-latest'.