### PR TITLE
Add eMMC installer

### DIFF
--- a/board/adi/ev-sc598-som/bootstrap/overlay/init
+++ b/board/adi/ev-sc598-som/bootstrap/overlay/init
@@ -5,7 +5,9 @@ mount -t sysfs sys /sys
 mount -t devtmpfs devtmpfs /dev
 
 set -e
+set -o pipefail
 
+EMMC_DEV=/dev/mmcblk0
 RCU0_STAT=0x3108C004
 BITP_RCU_STAT_BMODE=8
 BITM_RCU_STAT_BMODE=0x00000F00
@@ -32,15 +34,44 @@ case "$ans" in
 
     sync
     echo "SPI install complete"
-    echo
-    echo "Set the switch S1 to position 1 (SPI boot)."
-    echo "Waiting for switch..."
     ;;
   *)
     echo "Aborted."
-    while true; do sleep 3600; done
+    exit 1
     ;;
 esac
+
+echo
+echo "======== Install eMMC Image ========"
+echo
+echo "This will download emmc.img.gz from your PC and write it to ${EMMC_DEV}."
+echo
+printf "Enter your PC's IP address: "
+read -r PC_IP
+
+if [ -z "$PC_IP" ]; then
+    echo "No IP address provided. Skipping eMMC install."
+else
+    echo "Configuring network..."
+    ip link set eth0 up
+    udhcpc -i eth0 -n -q
+
+    URL="http://${PC_IP}:8000/emmc.img.gz"
+    echo "Downloading ${URL} to ${EMMC_DEV}..."
+
+    if ! wget -O - "$URL" | gunzip -c | dd of="$EMMC_DEV" bs=64K conv=fsync; then
+        echo
+        echo "ERROR: Failed to download, decompress, or write ${URL}"
+        echo
+        exit 1
+    fi
+
+    echo "eMMC install complete."
+fi
+
+echo
+echo "Set the switch S1 to position 1 (SPI boot)."
+echo "Waiting for switch..."
 
 while true; do
     val=$(devmem $RCU0_STAT 32)

--- a/board/adi/ev-sc598-som/post-image.sh
+++ b/board/adi/ev-sc598-som/post-image.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# TODO: remove compression once the MMC driver crash under memory pressure is fixed
+gzip -f -k "${BINARIES_DIR}/emmc.img"


### PR DESCRIPTION
Added eMMC installer step to the bootstrap init script. After flashing U-Boot
to SPI, the installer downloads and writes a compressed system image to eMMC.

The image is served compressed (.gz) as a temporary workaround for a suspected
race condition in the SC598 MMC kernel driver that causes a crash under memory
pressure when streaming the raw 7.6 GB image. This will be reverted once the
driver bug is fixed.