### PR TITLE
.github: add top-level workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,11 +2,7 @@ name: Build ADI artifacts
 
 on:
   workflow_dispatch:
-  pull_request:
-  release:
-    types: [published]
-  schedule:
-    - cron: '0 4 * * *' # 04:00 UTC (05:00/06:00 CET/CEST, 23:00/00:00 EST/EDT)
+  workflow_call:
 
 env:
   BR2_DL_DIR: ~/.buildroot-dl

--- a/.github/workflows/hw-test.yaml
+++ b/.github/workflows/hw-test.yaml
@@ -1,9 +1,7 @@
 name: Hardware Test
 
 on:
-  workflow_run:
-    workflows: ["Build ADI artifacts"]
-    types: [completed]
+  workflow_call:
 
 permissions:
   actions: read
@@ -12,7 +10,6 @@ permissions:
 
 jobs:
   hardware-test:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ vars.RUNNER_HW_TEST != '' && fromJSON(vars.RUNNER_HW_TEST) || 'ubuntu-latest' }}
     env:
       LG_COORDINATOR: ${{ secrets.LG_COORDINATOR }}
@@ -29,9 +26,7 @@ jobs:
         with:
           set: >
             {
-              "name": "adsp/smoke",
-              "labgrid_place":"MUN-01-SC598_EZKIT-01",
-              "workflow_run_url": "${{ github.event.workflow_run.url }}"
+              "name": "adsp/smoke"
             }
 
       - name: Run U-Boot hardware test
@@ -39,9 +34,7 @@ jobs:
         with:
           set: >
             {
-              "name":"adsp/u-boot",
-              "labgrid_place":"MUN-01-SC598_EZKIT-01",
-              "workflow_run_url": "${{ github.event.workflow_run.url }}"
+              "name": "adsp/u-boot"
             }
 
       - name: Run bootstrap hardware test
@@ -49,7 +42,5 @@ jobs:
         with:
           set: >
             {
-              "name":"adsp/bootstrap",
-              "labgrid_place":"MUN-01-SC598_EZKIT-01",
-              "workflow_run_url": "${{ github.event.workflow_run.url }}"
+              "name": "adsp/bootstrap"
             }

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -1,0 +1,29 @@
+name: Build and Hardware Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  release:
+    types: [published]
+  schedule:
+    - cron: '0 4 * * *' # 04:00 UTC (05:00/06:00 CET/CEST, 23:00/00:00 EST/EDT)
+
+jobs:
+  build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
+    permissions:
+      contents: write
+
+  hardware-test:
+    uses: ./.github/workflows/hw-test.yaml
+    needs: [build]
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'release' }}
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      id-token: write


### PR DESCRIPTION
Call the build and hardware test workflows from a shared top-level workflow so hardware tests can resolve build artifacts from the same workflow run.