### PR TITLE
readme.md: clarify defconfig location

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,10 @@ on `adi-2026.02-y`. `make buildroot-patch` re-applies any local patches and is
 idempotent — patches already present in the checkout are skipped via
 `git apply --check`.
 
+Be mindful of your environment variables, they may overwrite variables and
+affect the build. You can unset a single variable like `U` by suffixing with
+`env -u U make`.
+
 ## Buildroot patches
 
 `patches/buildroot/` holds ADI-specific Buildroot changes (package fix-ups,

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Generic support for ADI evaluation boards is implemented in the
 ```sh
 git clone --recurse-submodules https://github.com/analogdevicesinc/br2-external.git
 cd br2-external/buildroot
+# build Buildroot configuration for adi_sc598_ezkit
 make BR2_EXTERNAL="${PWD}/.." adi_sc598_ezkit_defconfig
 ```
 
@@ -28,7 +29,7 @@ to `cd buildroot/` first:
 
 ```sh
 make buildroot                   # clone & patch (skips if buildroot/ exists)
-make zynq_pluto_defconfig        # forwarded to Buildroot
+make zynq_pluto_defconfig        # from ./configs and forwarded to Buildroot
 make -j$(nproc)                  # forwarded; BR2_EXTERNAL is set for you
 ```
 


### PR DESCRIPTION
There are at least 3 repositories involved, clarify where the defconfig is stored.