### PR TITLE
.github/top-level: rm schedule, add ski-hw-test

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -2,11 +2,14 @@ name: Build and Hardware Test
 
 on:
   workflow_dispatch:
+   inputs:
+     skip-hw-test:
+       description: "Skip hardware tests"
+       default: false
+       type: boolean
   pull_request:
   release:
     types: [published]
-  schedule:
-    - cron: '0 4 * * *' # 04:00 UTC (05:00/06:00 CET/CEST, 23:00/00:00 EST/EDT)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -40,7 +43,7 @@ jobs:
   hardware-test:
     uses: ./.github/workflows/hw-test.yml
     needs: [build-buildroot]
-    if: ${{ github.event_name != 'schedule' && github.event_name != 'release' }}
+    if: ${{ !inputs.skip-hw-test && github.event_name != 'release' }}
     secrets: inherit
     permissions:
       actions: read


### PR DESCRIPTION
Remove daily nightly builds to dispatch through an scheduled API call instead (from Monday to Friday). Adds inputs.skip-hw-test to control if hardware tests should run. Removing the hardcoded cron allows users to fork the repository without having their quotas unknowingly wiped by our jobs.

Also allows dispatches to fine tune if they want to skip hw tests