### PR TITLE
configs: add plain initramfs rootfs flavor for hardware testing

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -22,6 +22,8 @@ jobs:
             flavor: debug
           - defconfig: adi_sc598_ezkit_defconfig
             flavor: bootstrap
+          - defconfig: adi_sc598_ezkit_defconfig
+            flavor: initramfs
           - defconfig: zynq_pluto_defconfig
           - defconfig: zynq_m2k_defconfig
           - defconfig: microblaze_adi_rootfs_defconfig

--- a/configs/initramfs.fragment
+++ b/configs/initramfs.fragment
@@ -1,0 +1,9 @@
+# Plain standalone initramfs for hardware testing.
+
+BR2_TARGET_ROOTFS_CPIO=y
+BR2_TARGET_ROOTFS_CPIO_GZIP=y
+# BR2_TARGET_ROOTFS_INITRAMFS is not set
+BR2_TARGET_ROOTFS_CPIO_UIMAGE=y
+
+# This is a RAM-only rootfs, so drop any post-image step.
+BR2_ROOTFS_POST_IMAGE_SCRIPT=""

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,8 @@ support/kconfig/merge_config.sh .config \
 - `configs/bootstrap.fragment`
     - Enable a minimal bootstrap / installer image.
     - Includes only the tools required to program boot media.
+- `configs/initramfs.fragment`
+    - Build a standalone, RAM-only file system for hardware testing.
 
 ### Example Builds
 
@@ -55,6 +57,16 @@ make BR2_EXTERNAL="${PWD}/.." adi_sc598_ezkit_defconfig
 support/kconfig/merge_config.sh .config \
     ../configs/buildroot.fragment \
     ../configs/bootstrap.fragment
+make -j$(nproc)
+```
+
+Initramfs for arm64:
+
+```sh
+make BR2_EXTERNAL="${PWD}/.." adi_sc598_ezkit_defconfig
+support/kconfig/merge_config.sh .config \
+    ../configs/buildroot.fragment \
+    ../configs/initramfs.fragment
 make -j$(nproc)
 ```
 


### PR DESCRIPTION
Adds an 'initramfs' flavor for ADSP boards that produces a standalone filesystem. One arm64 rootfs serves all 64bit ADSP boards.