### PR TITLE
.github/fedora: fix contents permission for release upload

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-rootfs:


### PR DESCRIPTION
The Fedora workflow fails to upload artifacts to a release:

> Run svenstaro/upload-release-action@v2
> Getting release by tag 2026.02-0.2.0.
> Uploading ci/mkosi.output/adsp-sc598-rootfs.tar.zst to adsp-sc598-rootfs-2026.02-0.2.0.tar.zst in release 2026.02-0.2.0.
> Error: Resource not accessible by integration - https://docs.github.com/rest


