### PR TITLE
.github/build: remove direct release trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,6 @@ on:
         required: false
         type: string
         default: ''
-  release:
-    types: [published]
-
 env:
   BR2_DL_DIR: ~/.buildroot-dl
 


### PR DESCRIPTION
The reusable build workflow has no defconfig input when triggered directly by a release. This invokes Buildroot without a defconfig and fails before the image build starts.

Releases are already handled by the top-level workflow, which passes each matrix defconfig to the reusable build workflow.